### PR TITLE
require ccsds 0.1.0-beta.16; fix level0split script after verification

### DIFF
--- a/scripts/catgen
+++ b/scripts/catgen
@@ -76,7 +76,7 @@ def generate_catalog(
         raise ValueError("(catgen) Failed to catalog any files")
 
     # catalog.normalize_hrefs(str(basedir.absolute()))
-    # catalog.make_all_asset_hrefs_relative()
+    catalog.make_all_asset_hrefs_relative()
     catalog.save(catalog_type=CatalogType.SELF_CONTAINED)
 
     return catalog

--- a/workflows/l0split/docker/Dockerfile
+++ b/workflows/l0split/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG basetag=latest
 
 FROM gitlab.ssec.wisc.edu:5555/sips/mdps-images/base:${basetag}
-RUN python3 -m pip install pystac "ccsds>=0.1.0b14"
+RUN python3 -m pip install pystac "ccsds>=0.1.0b16"
 COPY ./workflows/scripts/level0split /usr/local/bin/

--- a/workflows/l0split/docker/Dockerfile
+++ b/workflows/l0split/docker/Dockerfile
@@ -1,5 +1,11 @@
 ARG basetag=latest
 
 FROM gitlab.ssec.wisc.edu:5555/sips/mdps-images/base:${basetag}
+
+RUN cd /tmp && \
+  curl -sSf -L -o ccsds.tar.gz https://github.com/bmflynn/ccsds-rs/releases/download/0.1.0-beta.17/ccsds_0.1.0-beta.17.tar.gz && \
+  tar xf ccsds.tar.gz && \
+  mv -v x86_64-unknown-linux-musl/ccsds /usr/local/bin/
+
 RUN python3 -m pip install pystac "ccsds>=0.1.0b16"
 COPY ./workflows/scripts/level0split /usr/local/bin/

--- a/workflows/scripts/level0split
+++ b/workflows/scripts/level0split
@@ -29,9 +29,9 @@ def gather_catalog_inputs(fpath: Path, roles: list[str]) -> list[Path]:
     output_paths = []
     data = json.load(fpath.open())
     if data.get("type", "") == "FeatureCollection":
-        avail_items = ItemCollection.from_dict(data).items
+        avail_items = list(ItemCollection.from_dict(data).items)
     else:
-        avail_items = Catalog.from_dict(data).get_items(recursive=True)
+        avail_items = list(Catalog.from_dict(data, href=str(fpath)).get_items(recursive=True))
     LOG.info("%s catalog items", len(avail_items))  # type: ignore
     for item in avail_items:
         LOG.debug(item)
@@ -47,7 +47,7 @@ def gather_catalog_inputs(fpath: Path, roles: list[str]) -> list[Path]:
             if asset.href.startswith("/"):
                 path = Path(asset.href)
             else:
-                path = fpath.parent / Path(asset.href).name
+                path = fpath.parent / Path(asset.href)
             if not path.exists():
                 LOG.warning(
                     "Item %s asset role %s href %s does not exist locally",
@@ -88,7 +88,7 @@ def split_one(fpath: Path, dest: Path, file_duration: int) -> list[Path]:
             continue
         # packets all have CDS timecodes at start of secondary header
         timecode = (
-            ccsds.decode_cds_timecode(bytes(group.packets[0].data[6:15])) / 1000 / 1000
+            ccsds.decode_cds_timecode(bytes(group.packets[0].data[6:15])) / 1000
         )
         bucket = timecode - (timecode % file_duration)
         if bucket not in outputs:

--- a/workflows/viirsl1/docker/Dockerfile
+++ b/workflows/viirsl1/docker/Dockerfile
@@ -1,10 +1,19 @@
 FROM gitlab.ssec.wisc.edu:5555/sips/viirs_l1-build/viirsl1:v3.2.3
 
 USER root
-RUN dnf install -y python3.12-pip
+RUN dnf -yq install \
+    curl \
+    python3.12-pip && \
+  dnf -yqq clean all 
+
+RUN cd /tmp && \
+  curl -sSf -L -o ccsds.tar.gz https://github.com/bmflynn/ccsds-rs/releases/download/0.1.0-beta.17/ccsds_0.1.0-beta.17.tar.gz && \
+  tar xf ccsds.tar.gz && \
+  mv -v x86_64-unknown-linux-musl/ccsds /usr/local/bin/
 
 COPY docker/requirements.txt /tmp/
 RUN $APPDIR/bin/python3 -m pip install -r /tmp/requirements.txt
 COPY scripts/catgen /usr/local/bin/
 COPY workflows/viirsl1/scripts/level1a /usr/local/bin/
 
+ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
New version of ccsds lib fixes bug in packet group handling. Upon testing this new version there seemed to be several issues with the level0split script and its usage of ccsds. This commit was tested and the level0 output data was verified as fixed.